### PR TITLE
Streamlining the file_ignore_patterns

### DIFF
--- a/blogofile/site_init/_config.py
+++ b/blogofile/site_init/_config.py
@@ -120,14 +120,16 @@ blog.post_encoding = "utf-8"
 # These can be strings or compiled patterns.
 # Strings are assumed to be case insensitive.
 site.file_ignore_patterns = [
-    r".*([\/]|[\\])_.*",    #All files that start with an underscore
-    r".*([\/]|[\\])#.*",    #Emacs temporary files
-    r".*~$",                #Emacs temporary files
-    r".*([\/]|[\\])\.git$", #Git VCS dir
-    r".*([\/]|[\\])\.hg$",  #Mercurial VCS dir
-    r".*([\/]|[\\])\.bzr$", #Bazaar VCS dir
-    r".*([\/]|[\\])\.svn$", #Subversion VCS dir
-    r".*([\/]|[\\])CVS$"    #CVS dir
+    r".*/_.*",      # All files that start with an underscore
+    r".*/#.*",      # Emacs temporary files
+    r".*~$",        # Emacs temporary files
+    r".*/\..*\.swp" # Vim swap files
+    r".*/\.git$",   # Git VCS dir
+    r".*/.gitignore", # Git ignored files
+    r".*/\.hg$",    # Mercurial VCS dir
+    r".*/\.bzr$",   # Bazaar VCS dir
+    r".*/\.svn$",   # Subversion VCS dir
+    r".*/CVS$",     # CVS dir
     ]
 
 #### Default post filters ####

--- a/blogofile/site_init/blog_unit_test/_config.py
+++ b/blogofile/site_init/blog_unit_test/_config.py
@@ -130,14 +130,16 @@ blog.post_encoding = "utf-8"
 # These can be strings or compiled patterns.
 # Strings are assumed to be case insensitive.
 site.file_ignore_patterns = [
-    r".*([\/]|[\\])_.*",    #All files that start with an underscore
-    r".*([\/]|[\\])#.*",    #Emacs temporary files
-    r".*~$",                #Emacs temporary files
-    r".*([\/]|[\\])\.git$", #Git VCS dir
-    r".*([\/]|[\\])\.hg$",  #Mercurial VCS dir
-    r".*([\/]|[\\])\.bzr$", #Bazaar VCS dir
-    r".*([\/]|[\\])\.svn$", #Subversion VCS dir
-    r".*([\/]|[\\])CVS$"    #CVS dir
+    r".*/_.*",      # All files that start with an underscore
+    r".*/#.*",      # Emacs temporary files
+    r".*~$",        # Emacs temporary files
+    r".*/\..*\.swp" # Vim swap files
+    r".*/\.git$",   # Git VCS dir
+    r".*/.gitignore", # Git ignored files
+    r".*/\.hg$",    # Mercurial VCS dir
+    r".*/\.bzr$",   # Bazaar VCS dir
+    r".*/\.svn$",   # Subversion VCS dir
+    r".*/CVS$",     # CVS dir
     ]
 
 #### Default post filters ####

--- a/blogofile/util.py
+++ b/blogofile/util.py
@@ -28,6 +28,8 @@ def html_escape(text): #pragma: no cover
     
 def should_ignore_path(path):
     """See if a given path matches the ignore patterns"""
+    if os.path.sep == '\\':
+        path = path.replace('\\', '/')
     for p in bf.config.site.compiled_file_ignore_patterns:
         if p.match(path):
             return True


### PR DESCRIPTION
This commit simplifies the way, file_ignore_patterns is evaluated (backwards compatible, by the way).

On Windows systems, the backslashes in path are changed to forward slashes, which is perfectly valid (since forward slashes are path separators by now, too). That allows in the patterns to simply search for a single '/'.

If you don't like the patch, the patterns in the example _config.php files can still be simplified to a simple

<pre>
[/\\]
</pre>


instead of

<pre>
([\/]|[\\])
</pre>


(Escaping the forward slash is unnecessary for Python, since it doesn't use the delimiter style like Perl or PHP.)
