### PR TITLE
Log file read/decode errors

### DIFF
--- a/blogofile/site_init/blog_features/_controllers/blog/post.py
+++ b/blogofile/site_init/blog_features/_controllers/blog/post.py
@@ -296,7 +296,11 @@ def parse_posts(directory):
         #IMO codecs.open is broken on Win32.
         #It refuses to open files without replacing newlines with CR+LF
         #reverting to regular open and decode:
-        src = open(post_path,"r").read().decode(bf.config.controllers.blog.post_encoding)
+        try:
+            src = open(post_path,"r").read().decode(bf.config.controllers.blog.post_encoding)
+        except:
+            logger.exception("Error reading post: %s" % post_path)
+            raise
         try:
             p = Post(src, filename=post_fn)
         except PostParseException as e:


### PR DESCRIPTION
I had some pathological blog entries that contained inappropriately encoded Unicode entities that would bomb out the blogofile build process with a UnicodeDecodeError.  Unfortunately, out of the box, nothing will actually tell a user what file is being a problem!  I threw a tiny try/except and some extra logging at the exception level around the pain point and now life is happier for me.
