### PR TITLE
Changes for more standards-compliant HTML.

### DIFF
--- a/blogofile/site_init/blog_features/_controllers/blog/post.py
+++ b/blogofile/site_init/blog_features/_controllers/blog/post.py
@@ -45,6 +45,8 @@ reserved_field_names = {
     "path"       :"The path from the permalink of the post",
     "guid"       :"A unique hash for the post, if not provided it "\
         "is assumed that the permalink is the guid",
+    "slug"       :"The final part of the URL for the post, if not "\
+        "provided it is generated from the title.",
     "author"     :"The name of the author of the post",
     "filters"    :"The filter chain to apply to the entire post. "\
         "If not specified, a default chain based on the file extension is "\
@@ -87,6 +89,7 @@ class Post(object):
         self.filename = filename
         self.author = ""
         self.guid = None
+        self.slug = None
         self.draft = False
         self.filters = None
         self.__parse()
@@ -160,7 +163,10 @@ class Post(object):
         if not self.title:
             self.title = u"Untitled - {0}".format(
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-         
+        
+        if not self.slug:
+            self.slug = re.sub("[ ?]", "-", self.title).lower()
+
         if not self.date:
             self.date = datetime.datetime.now(pytz.timezone(self.__timezone))
         if not self.updated:
@@ -181,8 +187,7 @@ class Post(object):
             self.permalink = \
                     re.sub(":day", self.date.strftime("%d"), self.permalink)
             self.permalink = \
-                    re.sub(":title", re.sub("[ ?]", "-", self.title).lower(),
-                            self.permalink)
+                    re.sub(":title", self.slug, self.permalink)
 
             # TODO: slugification should be abstracted out somewhere reusable
             self.permalink = re.sub(

--- a/blogofile/site_init/blog_features/_controllers/blog/post.py
+++ b/blogofile/site_init/blog_features/_controllers/blog/post.py
@@ -45,8 +45,9 @@ reserved_field_names = {
     "path"       :"The path from the permalink of the post",
     "guid"       :"A unique hash for the post, if not provided it "\
         "is assumed that the permalink is the guid",
-    "slug"       :"The final part of the URL for the post, if not "\
-        "provided it is generated from the title.",
+    "slug"       :"The title part of the URL for the post, if not "\
+        "provided it is automatically generated from the title."\
+        "It is not used if permalink does not contain :title",
     "author"     :"The name of the author of the post",
     "filters"    :"The filter chain to apply to the entire post. "\
         "If not specified, a default chain based on the file extension is "\

--- a/blogofile/site_init/blog_features/_templates/post.mako
+++ b/blogofile/site_init/blog_features/_templates/post.mako
@@ -17,9 +17,9 @@ ${", ".join(category_links)}
  | <a href="${post.permalink}#disqus_thread">View Comments</a>
 % endif
 </small><p/>
-  <span class="post_prose">
+  <div class="post_prose">
     ${self.post_prose(post)}
-  </span>
+  </div>
 </div>
 
 <%def name="post_prose(post)">

--- a/blogofile/site_init/blog_features/_templates/post.mako
+++ b/blogofile/site_init/blog_features/_templates/post.mako
@@ -1,6 +1,6 @@
 <%page args="post"/>
 <div class="blog_post">
-  <a name="${post.title}" />
+  <a name="${post.slug}"></a>
   <h2 class="blog_post_title"><a href="${post.permapath()}" rel="bookmark" title="Permanent Link to ${post.title}">${post.title}</a></h2>
   <small>${post.date.strftime("%B %d, %Y at %I:%M %p")} | categories: 
 <% 


### PR DESCRIPTION
I made a few changes to make the HTML generated by the default blogofile install more standards compliant. Most of it is just markup changes.

The one slightly more complicated change is that I added a slug attribute to the Post class. This is so I could use that (the title with special characters replaced with '-') as the name value for the anchor tag, as the current method of using the title meant the name attribute contained spaces which is not valid in any (X)HTML standard.

It's currently possible for the user to set this, and I changed the text in reserved_field_names to reflect this, though I'm not sure if that is the best idea.
