### PR TITLE
wordpress2blogofile.py dies when importing wordpress_schema.py

### DIFF
--- a/blogofile/site_init/blog_features/_controllers/blog/permapage.py
+++ b/blogofile/site_init/blog_features/_controllers/blog/permapage.py
@@ -12,7 +12,9 @@ def run():
 def write_permapages():
     "Write blog posts to their permalink locations"
     site_re = re.compile(bf.config.site.url, re.IGNORECASE)
-    for post in blog.posts:
+    num_posts = len(blog.posts)
+    
+    for i, post in enumerate(blog.posts):
         if post.permalink:
             path = site_re.sub("", post.permalink)
             blog.logger.info("Writing permapage for post: {0}".format(path))
@@ -20,10 +22,6 @@ def write_permapages():
             #Permalinks MUST be specified. No permalink, no page.
             blog.logger.info("Post has no permalink: {0}".format(post.title))
             continue
-        try:
-            bf.util.mkdir(path)
-        except OSError:
-            pass
 
         env = {
             "post": post,
@@ -31,12 +29,10 @@ def write_permapages():
         }
 
         #Find the next and previous posts chronologically
-        for post_num in range(0,len(blog.posts)):
-            if blog.posts[post_num] == post:
-                if post_num < len(blog.posts) - 1:
-                    env['prev_post'] = blog.posts[post_num + 1]
-                if post_num > 0:
-                    env['next_post'] = blog.posts[post_num - 1]
-                break
+        if i < num_posts - 1:
+            env['prev_post'] = blog.posts[i + 1]
+        if i > 0:
+            env['next_post'] = blog.posts[i - 1]
+        
         bf.writer.materialize_template(
-                "permapage.mako", bf.util.path_join(path,"index.html"), env)
+                "permapage.mako", bf.util.path_join(path, "index.html"), env)

--- a/converters/wordpress_schema.py
+++ b/converters/wordpress_schema.py
@@ -76,9 +76,9 @@ class Post(Base):
             pass
         structure = structure.replace("%author%", self.author.user_nicename)
         return site_url.rstrip("/") + "/" + structure.lstrip("/")
-    
-class User(Base):
 
+
+class User(Base):
     __tablename__ = table_prefix + "wp_users"
     __table_args__ = {'autoload': True}
     id = sa.Column("ID", sa.Integer, primary_key=True)
@@ -99,7 +99,7 @@ class Term(Base):
 class TermTaxonomy(Base):
     __tablename__ = table_prefix + "wp_term_taxonomy"
     __table_args__ = {'autoload': True}
-    id = sa.Column('term_taxonomy_id', primary_key=True)
+    id = sa.Column('term_taxonomy_id', sa.Integer, primary_key=True)
     term_id = sa.Column("term_id",
             sa.ForeignKey(table_prefix + "wp_terms.term_id"))
     term = orm.relation("Term", primaryjoin="Term.id == TermTaxonomy.term_id")


### PR DESCRIPTION
When exporting from Wordpress, the export script dies with this exception:

Traceback (most recent call last):
 File "wordpress2blogofile.py", line 12, in <module>
   import wordpress_schema
 File "/vol/home/mmichie/tmp/blogofile/wordpress_schema.py", line 99,
in <module>
   class TermTaxonomy(Base):
 File "/vol/home/mmichie/tmp/blogofile/wordpress_schema.py", line
102, in TermTaxonomy
   id = sa.Column('term_taxonomy_id', primary_key=True)
 File "/usr/local/lib/python2.6/dist-packages/SQLAlchemy-0.6.5-
py2.6.egg/sqlalchemy/schema.py", line 766, in **init**
   raise exc.ArgumentError("'type' is required on Column objects "
sqlalchemy.exc.ArgumentError: 'type' is required on Column objects
which have no foreign keys.

This commit should fix it:

https://github.com/mpirnat/blogofile/commit/03faeb6908c306822d6a447ebda43399b6820e77
