### PR TITLE
Fix for category sorting

### DIFF
--- a/blogofile/site_init/blog_features/_controllers/blog/categories.py
+++ b/blogofile/site_init/blog_features/_controllers/blog/categories.py
@@ -62,6 +62,7 @@ def write_categories():
                 next_link = None
             
             env = {
+                "category": category,
                 "posts": page_posts,
                 "prev_link": prev_link,
                 "next_link": next_link

--- a/blogofile/site_init/blog_features/_controllers/blog/post.py
+++ b/blogofile/site_init/blog_features/_controllers/blog/post.py
@@ -295,12 +295,8 @@ class Category(object):
     def __repr__(self):
         return self.name
     
-    # FIXME: remove the first __cmp__ since the second one overwrites it?
     def __cmp__(self, other):
         return cmp(self.name, other.name)
-
-    def __cmp__(self, other):
-        return self is other
 
 
 def parse_posts(directory):


### PR DESCRIPTION
In post.py, the Category class had two **cmp** methods defined; unfortunately the incorrect second one wiped out the correct first one, causing a failure to sort categories by name.  Life is happier now.
