### PR TITLE
Change to the way WP post filenames are written.

### DIFF
--- a/converters/wordpress2blogofile.py
+++ b/converters/wordpress2blogofile.py
@@ -179,6 +179,7 @@ if __name__ == '__main__':
     else:
         os.mkdir("_posts")
 
+    post_num = 1
     for post in get_published_posts():
         yaml_data = {
             "title": post.post_title,
@@ -189,8 +190,8 @@ if __name__ == '__main__':
             "guid": post.guid
             }
         fn = u"{0}. {1}.html".format(
-                str(post.id).zfill(4),
-                post.post_title.strip())
+                str(post_num).zfill(4),
+                re.sub(r'[/!:?\-,\']', '', post.post_title.strip().lower().replace(' ', '_')))
         print "writing " + fn
         f = codecs.open(os.path.join("_posts", fn), "w", "utf-8")
         f.write("---\n")
@@ -198,3 +199,4 @@ if __name__ == '__main__':
         f.write("---\n")
         f.write(post.post_content.replace(u"\r\n", u"\n"))
         f.close()
+        post_num += 1


### PR DESCRIPTION
This puts an incrementing 4-digit number into the filenames instead of the wordpress post id. It also removes some special characters and turns spaces into underscores. Lastly it lowercases everything. 

Example:
1. Xonotic Player Interview: ProjektGhost.html becomes 0058_xonotic_player_interview_projektghost.html

*58 is the 58th post on my WP blog, which means more to me than a WP ID.

Please see the commit log for more details. 
