### PR TITLE
Enable markdown footnote syntax

### DIFF
--- a/blogofile/site_init/blog_features/_filters/markdown_template.py
+++ b/blogofile/site_init/blog_features/_filters/markdown_template.py
@@ -13,4 +13,4 @@ logging.getLogger("MARKDOWN").setLevel(logging.ERROR)
 
 
 def run(content):
-    return markdown.markdown(content)
+    return markdown.markdown(content, ['footnotes'])


### PR DESCRIPTION
Made a tiny change to enable the markdown footnote syntax.  This allows you to do:

Blah blah blah[^1] yadda yadda yadda.

[^1]: Footnote blah blah foo bar.
