### PR TITLE
Fix permalinks in RSS feeds for Apple Mail

### DIFF
--- a/blogofile/site_init/blog_templates/_templates/blog/rss.mako
+++ b/blogofile/site_init/blog_templates/_templates/blog/rss.mako
@@ -23,7 +23,7 @@
       <category><![CDATA[${category}]]></category>
 % endfor
 % if post.guid:
-      <guid>${post.guid}</guid>
+      <guid isPermaLink="false">${post.guid}</guid>
 % else:
       <guid isPermaLink="true">${post.permalink}</guid>
 % endif


### PR DESCRIPTION
Specify that GUID is not a permalink. Without this, some feed readers, like Apple Mail, try to build a permalink from the GUID. According to the RSS 2.0 spec, isPermalink defaults to "true", so "false" needs to be specified. (Most other feed readers wisely use the "link" attribute as the permalink, but they're not required to.)
