### PR TITLE
better error messages for undefined variables in mako templates

### DIFF
--- a/blogofile/template.py
+++ b/blogofile/template.py
@@ -108,11 +108,13 @@ class MakoTemplate(Template):
             self.mako_template = mako.template.Template(
                 src,
                 output_encoding="utf-8",
+                strict_undefined=True,
                 lookup=self.template_lookup)
         else:
             self.mako_template = self.template_lookup.get_template(
                 template_name)
             self.mako_template.output_encoding = "utf-8"
+            self.mako_template.strict_undefined = True
 
     @classmethod
     def create_lookup(cls):


### PR DESCRIPTION
The following template (mako_undefined.html.mako)
<%
    mistyeped_variable = 'some value'
%>
Hello, this is the mistyped_variable value ${mistyped_variable}
--- EOF ---

In non strict mode produces a similar error

Traceback (most recent call last):
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\blogofile-0.8b1-py2.7.egg\blogofile\template.py", line 157, in render
    rendered = self.mako_template.render(*_self)
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\template.py", line 412, in render
    return runtime._render(self, self.callable_, args, data)
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\runtime.py", line 766, in _render
    *__kwargs_for_callable(callable_, data))
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\runtime.py", line 798, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\runtime.py", line 824, in _exec_template
    callable_(context, _args, *_kwargs)
  File "memory:0x2d9da30", line 4, in render_body
    Hello, this is the mistyped_variable value ${mistyped_variable}
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\runtime.py", line 194, in **str**
    raise NameError("Undefined")
NameError: Undefined

After adding strict_undefined=True, the error message is the following, which is more useful IMO:

Traceback (most recent call last):
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\blogofile-0.8b1-py2.7.egg\blogofile\template.py", line 159, in render
    rendered = self.mako_template.render(*_self)
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\template.py", line 412, in render
    return runtime._render(self, self.callable_, args, data)
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\runtime.py", line 766, in _render
    *__kwargs_for_callable(callable_, data))
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\runtime.py", line 798, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "c:\lib\Python\2.7.1-x86\lib\site-packages\mako-0.7.2-py2.7.egg\mako\runtime.py", line 824, in _exec_template
    callable_(context, _args, *_kwargs)
  File "memory:0x2c70250", line 1, in render_body
    <%
NameError: 'mistyped_variable' is not defined

--- DISCLAIMERS --
- This commit was made via the github web interface
- I've tested it locally using the installed the 0.81b version, not github HEAD
  *\* even then, I have not tested the second line of modification, only the first 
  *\* eventually I get around to setting up a blogofile development environment though
- Nonetheless, I thought in this case a pull requests might be easier than to open an issue and wait for someone (me) to eventually fix it
